### PR TITLE
feat: make icon delimiter modifiable in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,18 +82,22 @@ google = "gg"
 ```
 
 - You can deduplicate icons with the `dedup` parameter in the `root` section of config file.
-- You can also modify delimiter between multiple clients with the `delim` parameter
 
 ```
 dedup = true
-delim = " " # NARROW NO-BREAK SPACE
 ...
 [title."(xterm|(?i)kitty|alacritty)"]
 "(?i)neomutt" = "mail"
 ncdu = "file manager"
 ...
 ```
-
+- You can also modify delimiter between multiple clients with the `delim` parameter in the `format` section of config file
+```
+dedup = true
+[format]
+delim = " " # NARROW NO-BREAK SPACE
+...
+```
 No need to restart the applications then, there is an autoreload.
 
 _Hint_: You can use glyphsearch and copy the unicode icon of your font for example https://glyphsearch.com/?query=book&copy=unicode

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ google = "gg"
 ```
 
 - You can deduplicate icons with the `dedup` parameter in the `root` section of config file.
+- You can also modify delimiter between multiple clients with the `delim` parameter
 
 ```
 dedup = true
+delim = " " # NARROW NO-BREAK SPACE
 ...
 [title."(xterm|(?i)kitty|alacritty)"]
 "(?i)neomutt" = "mail"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,6 +21,12 @@ pub struct ConfigFileRaw {
     pub exclude: FxHashMap<String, String>,
     #[serde(default)]
     pub dedup: bool,
+    #[serde(default="default_delim")]
+    pub delim: String,
+}
+
+fn default_delim() -> String {
+    " ".to_string()
 }
 
 pub struct ConfigFile {
@@ -28,6 +34,7 @@ pub struct ConfigFile {
     pub title: Vec<(Regex, Vec<(Regex, String)>)>,
     pub exclude: Vec<(Regex, Regex)>,
     pub dedup: bool,
+    pub delim: String,
 }
 
 impl Config {
@@ -62,6 +69,8 @@ pub fn read_config_file(cfg_path: &PathBuf) -> Result<ConfigFile, Box<dyn Error>
         toml::from_str(&config_string).map_err(|e| format!("Unable to parse: {e:?}"))?;
 
     let dedup = config.dedup;
+
+    let delim = config.delim;
 
     let icons = config
         .icons
@@ -104,6 +113,7 @@ pub fn read_config_file(cfg_path: &PathBuf) -> Result<ConfigFile, Box<dyn Error>
         title,
         exclude,
         dedup,
+        delim,
     })
 }
 
@@ -112,6 +122,7 @@ pub fn create_default_config(cfg_path: &PathBuf) -> Result<&'static str, Box<dyn
 # Deduplicate icons if enable.
 # A superscripted counter will be added.
 dedup = false
+delim = " "
 
 [icons]
 # Add your icons mapping

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,6 @@
 use regex::Regex;
 use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use serde::Deserialize;
 use std::error::Error;
 use std::fs;
@@ -19,17 +20,19 @@ pub struct ConfigFileRaw {
     pub title: FxHashMap<String, FxHashMap<String, String>>,
     #[serde(default)]
     pub exclude: FxHashMap<String, String>,
-    #[serde(default)]//="default_format")]
+    #[serde(default="default_format")]
     pub format: FxHashMap<String, String>,
     #[serde(default)]
     pub dedup: bool,
 }
 
-/*fn default_format() -> FxHashMap<String, String> {
-    FxHashMap<Stringfrom([
-    ("delim".to_string(), " ".to_string()),
-])
-}*/
+
+fn default_format() -> FxHashMap<String, String> {
+    let mut map = FxHashMap::default();
+    map.insert("delim".to_string(), " ".to_string());
+    map
+}
+
 
 pub struct ConfigFile {
     pub icons: Vec<(Regex, String)>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,5 @@
 use regex::Regex;
 use rustc_hash::FxHashMap;
-use std::collections::HashMap;
 use serde::Deserialize;
 use std::error::Error;
 use std::fs;
@@ -28,9 +27,7 @@ pub struct ConfigFileRaw {
 
 
 fn default_format() -> FxHashMap<String, String> {
-    let mut map = FxHashMap::default();
-    map.insert("delim".to_string(), " ".to_string());
-    map
+    [("delim".to_string(), " ".to_string())].iter().cloned().collect()
 }
 
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,24 +19,15 @@ pub struct ConfigFileRaw {
     pub title: FxHashMap<String, FxHashMap<String, String>>,
     #[serde(default)]
     pub exclude: FxHashMap<String, String>,
-    #[serde(default="default_format")]
-    pub format: FxHashMap<String, String>,
     #[serde(default)]
-    pub dedup: bool,
+    pub format: FxHashMap<String, String>,
 }
-
-
-fn default_format() -> FxHashMap<String, String> {
-    [("delim".to_string(), " ".to_string())].iter().cloned().collect()
-}
-
 
 pub struct ConfigFile {
     pub icons: Vec<(Regex, String)>,
     pub title: Vec<(Regex, Vec<(Regex, String)>)>,
     pub exclude: Vec<(Regex, Regex)>,
     pub format: FxHashMap<String, String>,
-    pub dedup: bool,
 }
 
 impl Config {
@@ -69,8 +60,6 @@ pub fn read_config_file(cfg_path: &PathBuf) -> Result<ConfigFile, Box<dyn Error>
 
     let config: ConfigFileRaw =
         toml::from_str(&config_string).map_err(|e| format!("Unable to parse: {e:?}"))?;
-
-    let dedup = config.dedup;
 
     let format = config.format;
 
@@ -115,7 +104,6 @@ pub fn read_config_file(cfg_path: &PathBuf) -> Result<ConfigFile, Box<dyn Error>
         title,
         exclude,
         format,
-        dedup,
     })
 }
 
@@ -123,10 +111,10 @@ pub fn create_default_config(cfg_path: &PathBuf) -> Result<&'static str, Box<dyn
     let default_config = r#"
 # Deduplicate icons if enable.
 # A superscripted counter will be added.
-dedup = false
 
 [format]
 delim = " "
+dedup = false
 
 [icons]
 # Add your icons mapping

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,22 +19,24 @@ pub struct ConfigFileRaw {
     pub title: FxHashMap<String, FxHashMap<String, String>>,
     #[serde(default)]
     pub exclude: FxHashMap<String, String>,
+    #[serde(default)]//="default_format")]
+    pub format: FxHashMap<String, String>,
     #[serde(default)]
     pub dedup: bool,
-    #[serde(default="default_delim")]
-    pub delim: String,
 }
 
-fn default_delim() -> String {
-    " ".to_string()
-}
+/*fn default_format() -> FxHashMap<String, String> {
+    FxHashMap<Stringfrom([
+    ("delim".to_string(), " ".to_string()),
+])
+}*/
 
 pub struct ConfigFile {
     pub icons: Vec<(Regex, String)>,
     pub title: Vec<(Regex, Vec<(Regex, String)>)>,
     pub exclude: Vec<(Regex, Regex)>,
+    pub format: FxHashMap<String, String>,
     pub dedup: bool,
-    pub delim: String,
 }
 
 impl Config {
@@ -70,7 +72,7 @@ pub fn read_config_file(cfg_path: &PathBuf) -> Result<ConfigFile, Box<dyn Error>
 
     let dedup = config.dedup;
 
-    let delim = config.delim;
+    let format = config.format;
 
     let icons = config
         .icons
@@ -112,8 +114,8 @@ pub fn read_config_file(cfg_path: &PathBuf) -> Result<ConfigFile, Box<dyn Error>
         icons,
         title,
         exclude,
+        format,
         dedup,
-        delim,
     })
 }
 
@@ -122,6 +124,8 @@ pub fn create_default_config(cfg_path: &PathBuf) -> Result<&'static str, Box<dyn
 # Deduplicate icons if enable.
 # A superscripted counter will be added.
 dedup = false
+
+[format]
 delim = " "
 
 [icons]

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -72,8 +72,16 @@ impl Renamer {
                     *count += 1;
                 })
                 .or_insert(1);
+            let dedup = {
+                        let cfg = self.cfg.lock()?;
+                        if cfg.config.format.contains_key("dedup") {
 
-            let should_dedup = self.cfg.lock()?.config.dedup && (*counter > 1);
+                            matches!(&cfg.config.format["dedup"][..], "true"| "1")
+                        } else {
+                            false
+                        }
+                    };
+            let should_dedup =  dedup && (*counter > 1);
 
             if self.args.verbose && should_dedup {
                 println!("- window: class '{class}' is duplicate {counter}x")

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -86,12 +86,17 @@ impl Renamer {
             let workspace = workspaces
                 .entry(workspace_id)
                 .or_insert_with(|| "".to_string());
-
-            let delim = match workspace.is_empty() {
-                false=>self.cfg.lock()?.config.format["delim"].to_string(),
-                true=>"".to_string()
-            };
-            *workspace =
+            let delim = if workspace.is_empty() {
+                            "".to_string()
+                        } else {
+                        let cfg = self.cfg.lock()?;
+                        if cfg.config.format.contains_key("delim") {
+                            cfg.config.format["delim"].to_string()
+                        } else {
+                            " ".to_string()
+                        }
+                    };
+                       *workspace =
                 handle_new_icon(icon, delim, client.fullscreen, workspace, should_dedup, *counter);
         }
 

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -87,8 +87,12 @@ impl Renamer {
                 .entry(workspace_id)
                 .or_insert_with(|| "".to_string());
 
+            let delim = match workspace.is_empty() {
+                false=>self.cfg.lock()?.config.delim.to_string(),
+                true=>"".to_string()
+            };
             *workspace =
-                handle_new_icon(icon, client.fullscreen, workspace, should_dedup, *counter);
+                handle_new_icon(icon, delim , client.fullscreen, workspace, should_dedup, *counter);
         }
 
         workspaces
@@ -214,6 +218,7 @@ impl Renamer {
 #[inline(always)]
 fn handle_new_icon(
     icon: String,
+    delim: String,
     fullscreen: bool,
     workspace: &str,
     should_dedup: bool,
@@ -227,13 +232,13 @@ fn handle_new_icon(
             if counter > 2 {
                 workspace.replace(
                     &format!("{icon}{prev_counter_super}"),
-                    &format!("[{icon}] {icon}{prev_counter_super}"),
+                    &format!("[{icon}]{delim}{icon}{prev_counter_super}"),
                 )
             } else {
-                workspace.replace(&icon, &format!("[{icon}] {icon}"))
+                workspace.replace(&icon, &format!("[{icon}]{delim}{icon}"))
             }
         }
-        (true, false) => format!("{workspace} [{icon}]"),
+        (true, false) => format!("{workspace}{delim}[{icon}]"),
         (false, true) => {
             if counter > 2 {
                 workspace.replace(
@@ -244,13 +249,13 @@ fn handle_new_icon(
                 workspace.replace(&icon, &format!("{icon}{counter_super}"))
             }
         }
-        (false, false) => format!("{workspace} {icon}"),
+        (false, false) => format!("{workspace}{delim}{icon}"),
     }
 }
 
 #[inline(always)]
 fn rename_cmd(id: i32, apps: &str) -> Result<(), Box<dyn Error>> {
-    let text = format!("{id}:{apps}");
+    let text = format!("{id}: {apps}");
     let content = (!apps.is_empty()).then_some(text.as_str());
     hyprland::dispatch!(RenameWorkspace, id, content)?;
 

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -88,7 +88,7 @@ impl Renamer {
                 .or_insert_with(|| "".to_string());
 
             let delim = match workspace.is_empty() {
-                false=>self.cfg.lock()?.config.delim.to_string(),
+                false=>self.cfg.lock()?.config.format["delim"].to_string(),
                 true=>"".to_string()
             };
             *workspace =

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -92,7 +92,7 @@ impl Renamer {
                 true=>"".to_string()
             };
             *workspace =
-                handle_new_icon(icon, delim , client.fullscreen, workspace, should_dedup, *counter);
+                handle_new_icon(icon, delim, client.fullscreen, workspace, should_dedup, *counter);
         }
 
         workspaces


### PR DESCRIPTION
## Description
This PR makes the delimiter between icons modifiable in config file, instead of using forced space.
It can be modified by setting `delim="something"` in config.

Examples:
 `delim=" - "` 
![image](https://user-images.githubusercontent.com/52415835/236354924-33637b84-cc7c-433e-ab9f-4c5997102209.png)
`delim=" " #SPACE`
![image](https://user-images.githubusercontent.com/52415835/236355027-259216cc-6402-40e4-9b7e-1ae9f86e9d6a.png)
 `delim=" " # NARROW NO-BREAK SPACE`
![image](https://user-images.githubusercontent.com/52415835/236355131-20e71256-c95d-4223-b8a9-300a43885a81.png)
Someone might prefer no delimiter, or possibly set background color/background color of the delimiter
`delim=" <span bgcolor='white'> </span> "`
![image](https://user-images.githubusercontent.com/52415835/236355788-06f906f6-6e31-413a-ab33-2f875e42ed02.png)
(requires some patches for hyprland-rs and waybar-hyprland)

I am VERY open to feedback, it is my very first piece of code written in Rust and I have basically no knowledge about this programming language.

## Type of change

- [x] New feature (non-breaking change which adds functionality) - It should behave the same if the config is not modified
-  ~~Breaking change: If config file is not modified, spaces will disappear between icons.~~
- [x] set the default " ", when delim is not set in config
- [x] This change requires a documentation update 

## How Has This Been Tested?

No extensive testing, I have just tried modifying the delim option., (I should write at least 1 test)

## Future
In next PR/PRs I would like to make whole "workspace pattern" modifiable in config, specifically this:
`let text = format!("{id}: {apps}");`

And then the same for general "icon"/"icon with counter".. So it is possible to format it as people wish, for example setting a different color for the counter of icons.
