### PR TITLE
feat: Specify config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ hyprland-autoname-workspaces
 
 ## Configuration
 
-The config file can be specified using the `-c <CONFIG>` option, otherwise it defaults to `~/.config/hyprland-autoname-workspaces/config.toml`.
+The config file can be specified using the `-c <CONFIG>` option, otherwise it defaults to `~/.config/hyprland-autoname-workspaces/config.toml`. If you specify a path that doesn't exist, a default configuration file will be generated.
 
 _You can use regex everywhere, and its case sensitive by default_
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ hyprland-autoname-workspaces
 
 ## Configuration
 
-In the config file `~/.config/hyprland-autoname-workspaces/config.toml`.
+The config file can be specified using the `-c <CONFIG>` option, otherwise it defaults to `~/.config/hyprland-autoname-workspaces/config.toml`.
 
 _You can use regex everywhere, and its case sensitive by default_
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -105,10 +105,7 @@ pub struct ConfigFile {
 }
 
 impl Config {
-    pub fn new() -> Result<Config, Box<dyn Error>> {
-        let xdg_dirs = xdg::BaseDirectories::with_prefix("hyprland-autoname-workspaces")?;
-        let cfg_path = xdg_dirs.place_config_file("config.toml")?;
-
+    pub fn new(cfg_path: PathBuf) -> Result<Config, Box<dyn Error>> {
         if !cfg_path.exists() {
             _ = create_default_config(&cfg_path);
         }
@@ -116,6 +113,20 @@ impl Config {
         let config = read_config_file(&cfg_path)?;
 
         Ok(Config { config, cfg_path })
+    }
+}
+
+pub fn get_config_path(args: &Option<String>) -> Result<PathBuf, Box<dyn Error>> {
+    match args {
+        Some(path) => {
+            let cfg_path = PathBuf::from(path);
+            Ok(cfg_path)
+        }
+        _ => {
+            let xdg_dirs = xdg::BaseDirectories::with_prefix("hyprland-autoname-workspaces")?;
+            let cfg_path = xdg_dirs.place_config_file("config.toml")?;
+            Ok(cfg_path)
+        }
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -123,7 +123,7 @@ pub fn get_config_path(args: &Option<String>) -> Result<PathBuf, Box<dyn Error>>
         }
         _ => {
             let xdg_dirs = xdg::BaseDirectories::with_prefix("hyprland-autoname-workspaces")?;
-            let cfg_path = xdg_dirs.place_config_file("config.toml")?;
+            xdg_dirs.place_config_file("config.toml")?
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -117,7 +117,7 @@ impl Config {
 }
 
 pub fn get_config_path(args: &Option<String>) -> Result<PathBuf, Box<dyn Error>> {
-    match args {
+    let cfg_path = match args {
         Some(path) => {
             let cfg_path = PathBuf::from(path);
             Ok(cfg_path)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -125,7 +125,8 @@ pub fn get_config_path(args: &Option<String>) -> Result<PathBuf, Box<dyn Error>>
             let xdg_dirs = xdg::BaseDirectories::with_prefix("hyprland-autoname-workspaces")?;
             xdg_dirs.place_config_file("config.toml")?
         }
-    }
+    };
+    Ok(cfg_path)
 }
 
 pub fn read_config_file(cfg_path: &PathBuf) -> Result<ConfigFile, Box<dyn Error>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -124,7 +124,6 @@ pub fn get_config_path(args: &Option<String>) -> Result<PathBuf, Box<dyn Error>>
         _ => {
             let xdg_dirs = xdg::BaseDirectories::with_prefix("hyprland-autoname-workspaces")?;
             let cfg_path = xdg_dirs.place_config_file("config.toml")?;
-            Ok(cfg_path)
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -119,7 +119,7 @@ impl Config {
 pub fn get_config_path(args: &Option<String>) -> Result<PathBuf, Box<dyn Error>> {
     let cfg_path = match args {
         Some(path) => {
-            let cfg_path = PathBuf::from(path);
+            PathBuf::from(path)
         }
         _ => {
             let xdg_dirs = xdg::BaseDirectories::with_prefix("hyprland-autoname-workspaces")?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -120,7 +120,6 @@ pub fn get_config_path(args: &Option<String>) -> Result<PathBuf, Box<dyn Error>>
     let cfg_path = match args {
         Some(path) => {
             let cfg_path = PathBuf::from(path);
-            Ok(cfg_path)
         }
         _ => {
             let xdg_dirs = xdg::BaseDirectories::with_prefix("hyprland-autoname-workspaces")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,14 +7,16 @@ use crate::params::Args;
 use crate::renamer::*;
 
 use clap::Parser;
+use config::get_config_path;
 use signal_hook::consts::{SIGINT, SIGTERM};
 use signal_hook::iterator::Signals;
 use single_instance::SingleInstance;
 use std::{process, thread};
 
 fn main() {
-    let cfg = Config::new().expect("Unable to read config");
     let args = Args::parse();
+    let cfg_path = get_config_path(&args.config).unwrap();
+    let cfg = Config::new(cfg_path).expect("Unable to read config");
 
     if args.dump {
         println!("{:#?}", &cfg);

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -8,4 +8,7 @@ pub struct Args {
     pub verbose: bool,
     #[arg(short, long)]
     pub dump: bool,
+    /// Config file
+    #[arg(short, long, default_value = None)]
+    pub config: Option<String>,
 }

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -157,7 +157,7 @@ impl Renamer {
             println!("Reloading config !");
             // Clojure to force quick release of lock
             {
-                match Config::new() {
+                match Config::new(self.cfg.lock()?.cfg_path.clone()) {
                     Ok(config) => self.cfg.lock()?.config = config.config,
                     Err(err) => println!("Unable to reload config: {err:?}"),
                 }
@@ -437,6 +437,7 @@ mod tests {
         let renamer = Renamer::new(
             Config { cfg_path, config },
             Args {
+                config: Some("/tmp/hyprland-autoname-workspaces-test.toml".to_string()),
                 verbose: false,
                 dump: false,
             },
@@ -453,6 +454,7 @@ mod tests {
         let renamer = Renamer::new(
             Config { cfg_path, config },
             Args {
+                config: Some("/tmp/hyprland-autoname-workspaces-test.toml".to_string()),
                 verbose: false,
                 dump: false,
             },
@@ -471,6 +473,7 @@ mod tests {
         let renamer = Renamer::new(
             Config { cfg_path, config },
             Args {
+                config: Some("/tmp/hyprland-autoname-workspaces-test.toml".to_string()),
                 verbose: false,
                 dump: false,
             },
@@ -489,6 +492,7 @@ mod tests {
         let renamer = Renamer::new(
             Config { cfg_path, config },
             Args {
+                config: Some("/tmp/hyprland-autoname-workspaces-test.toml".to_string()),
                 verbose: false,
                 dump: false,
             },
@@ -507,6 +511,7 @@ mod tests {
         let renamer = Renamer::new(
             Config { cfg_path, config },
             Args {
+                config: Some("/tmp/hyprland-autoname-workspaces-test.toml".to_string()),
                 verbose: false,
                 dump: false,
             },
@@ -529,6 +534,7 @@ mod tests {
         let renamer = Renamer::new(
             Config { cfg_path, config },
             Args {
+                config: Some("/tmp/hyprland-autoname-workspaces-test.toml".to_string()),
                 verbose: false,
                 dump: false,
             },


### PR DESCRIPTION
## Description

Add the ability to specify a configuration file outside of the default path using `-c, --config <CONFIG>`.

Forgive any crappy code, my rust is at a pretty noob stage.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `cargo test`
- [x] Manually testing a configuration file outside the default location using the `-c` flag
- [x] Testing a configuration file gets generate automatically when specified and non-existant

I have not generated any automated tests for this.