### PR TITLE
fix: active icon default fallback first to icon default then "no icon"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,15 +466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,14 +482,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -848,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",

--- a/src/renamer/icon.rs
+++ b/src/renamer/icon.rs
@@ -24,6 +24,14 @@ impl IconConfig {
             ActiveClass(_, icon) | ActiveTitle(_, icon) => icon.to_string(),
         }
     }
+
+    pub fn rule(&self) -> Rule {
+        match &self {
+            Title(rule, _) | Class(rule, _) => rule.to_string(),
+            ActiveClass(rule, _) | ActiveTitle(rule, _) => rule.to_string(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl Renamer {
@@ -83,12 +91,9 @@ impl Renamer {
             .unwrap_or(IconConfig::Default("no icon".to_string()));
 
         let icon_default_active = self.find_icon("DEFAULT", "", true, config).unwrap_or({
-            match icon_default.clone() {
-                IconConfig::Class(rule, icon) if rule == "DEFAULT" => {
-                    IconConfig::ActiveClass(rule, icon)
-                }
-                _ => IconConfig::ActiveDefault("no icon".to_string()),
-            }
+            self.find_icon("DEFAULT", "", false, config)
+                .map(|i| IconConfig::ActiveClass(i.rule(), i.icon()))
+                .unwrap_or(IconConfig::ActiveDefault("no icon".to_string()))
         });
 
         if is_active {

--- a/src/renamer/icon.rs
+++ b/src/renamer/icon.rs
@@ -81,9 +81,15 @@ impl Renamer {
         let icon_default = self
             .find_icon("DEFAULT", "", false, config)
             .unwrap_or(IconConfig::Default("no icon".to_string()));
-        let icon_default_active = self
-            .find_icon("DEFAULT", "", true, config)
-            .unwrap_or(IconConfig::ActiveDefault("no icon".to_string()));
+
+        let icon_default_active = self.find_icon("DEFAULT", "", true, config).unwrap_or({
+            match icon_default.clone() {
+                IconConfig::Class(rule, icon) if rule == "DEFAULT" => {
+                    IconConfig::ActiveClass(rule, icon)
+                }
+                _ => IconConfig::ActiveDefault("no icon".to_string()),
+            }
+        });
 
         if is_active {
             icon_active.unwrap_or(match icon {

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -1374,4 +1374,88 @@ mod tests {
 
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn test_no_default_class_active_fallback_to_class_default() {
+        let mut config = crate::config::read_config_file(None).unwrap();
+
+        config
+            .icons_active
+            .push((Regex::new("DEFAULT").unwrap(), "default active".to_string()));
+
+        println!("config => {:#?}", config);
+        let renamer = Renamer::new(
+            Config {
+                cfg_path: None,
+                config: config.clone(),
+            },
+            Args {
+                verbose: false,
+                debug: false,
+                config: None,
+                dump: false,
+            },
+        );
+
+        let expected = [(1, "default active".to_string())].into_iter().collect();
+
+        let actual = renamer.generate_workspaces_string(
+            vec![AppWorkspace {
+                id: 1,
+                clients: vec![AppClient {
+                    class: "kitty".to_string(),
+                    title: "~".to_string(),
+                    is_active: true,
+                    is_fullscreen: false,
+                    matched_rule: renamer.parse_icon(
+                        "kitty".to_string(),
+                        "~".to_string(),
+                        true,
+                        &config,
+                    ),
+                }],
+            }],
+            &config,
+        );
+
+        assert_eq!(actual, expected);
+
+        let config = crate::config::read_config_file(None).unwrap();
+
+        let renamer = Renamer::new(
+            Config {
+                cfg_path: None,
+                config: config.clone(),
+            },
+            Args {
+                verbose: false,
+                debug: false,
+                config: None,
+                dump: false,
+            },
+        );
+
+        let actual = renamer.generate_workspaces_string(
+            vec![AppWorkspace {
+                id: 1,
+                clients: vec![AppClient {
+                    class: "kitty".to_string(),
+                    title: "~".to_string(),
+                    is_active: true,
+                    is_fullscreen: false,
+                    matched_rule: renamer.parse_icon(
+                        "kitty".to_string(),
+                        "~".to_string(),
+                        true,
+                        &config,
+                    ),
+                }],
+            }],
+            &config,
+        );
+
+        let expected = [(1, "\u{f059} kitty".to_string())].into_iter().collect();
+
+        assert_eq!(actual, expected);
+    }
 }


### PR DESCRIPTION
In the active case, this return the DEFAULT icon if no ACTIVE DEFAULT, then "no icon".