### PR TITLE
feat: Add dedup_inactive deduplication option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "parking_lot"

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,5 +1,6 @@
 [format]
 dedup = true
+dedup_inactive_fullscreen = false
 delim = " "
 client = "{icon}{delim}"
 client_active = "<span color='red'>{icon}</span>"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,10 +62,10 @@ impl Default for ConfigFormatRaw {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ConfigFormatRaw {
-    #[serde(default, alias = "dedup")]
-    pub dedup_active: bool,
     #[serde(default)]
-    pub dedup_inactive: bool,
+    pub dedup: bool,
+    #[serde(default)]
+    pub dedup_inactive_fullscreen: bool,
     #[serde(default = "default_delim_formatter")]
     pub delim: String,
     #[serde(default = "default_workspace_formatter")]
@@ -164,8 +164,8 @@ pub fn create_default_config(cfg_path: &PathBuf) -> Result<&'static str, Box<dyn
 # [format]
 # Deduplicate icons if enable.
 # A superscripted counter will be added.
-# dedup_active = false
-# dedup_inactive = false # dedup more
+# dedup = false
+# dedup_inactive_fullscreen = false # dedup more
 # window delimiter
 # delim = " "
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,8 +62,10 @@ impl Default for ConfigFormatRaw {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ConfigFormatRaw {
+    #[serde(default, alias = "dedup")]
+    pub dedup_active: bool,
     #[serde(default)]
-    pub dedup: bool,
+    pub dedup_inactive: bool,
     #[serde(default = "default_delim_formatter")]
     pub delim: String,
     #[serde(default = "default_workspace_formatter")]
@@ -162,7 +164,8 @@ pub fn create_default_config(cfg_path: &PathBuf) -> Result<&'static str, Box<dyn
 # [format]
 # Deduplicate icons if enable.
 # A superscripted counter will be added.
-# dedup = false
+# dedup_active = false
+# dedup_inactive = false # dedup more
 # window delimiter
 # delim = " "
 

--- a/src/renamer/formatter.rs
+++ b/src/renamer/formatter.rs
@@ -26,7 +26,7 @@ impl Renamer {
             .iter()
             .map(|workspace| {
                 let mut counted =
-                    generate_counted_clients(workspace.clients.clone(), config.format.dedup);
+                    generate_counted_clients(workspace.clients.clone(), config.format.dedup_active);
 
                 let workspace_output = counted
                     .iter_mut()
@@ -45,7 +45,8 @@ impl Renamer {
         let config_format = &config.format;
         let client = client.clone();
 
-        let is_dedup = config_format.dedup && (counter > 1);
+        let is_dedup_active = config_format.dedup_active && (counter > 1);
+        let is_dedup_inactive = config_format.dedup_inactive;
 
         let counter_sup = to_superscript(counter);
         let prev_counter = (counter - 1).to_string();
@@ -91,7 +92,9 @@ impl Renamer {
             println!("client: {:?}\nformatter vars => {:#?}", client, vars);
         }
 
-        match (client.is_fullscreen, is_dedup) {
+        let is_grouped = client.is_fullscreen && (client.is_active || !is_dedup_inactive);
+
+        match (is_grouped, is_dedup_active) {
             (true, true) => formatter(fmt_client_dup_fullscreen, &vars),
             (false, true) => formatter(fmt_client_dup, &vars),
             (true, false) => formatter(fmt_client_fullscreen, &vars),

--- a/src/renamer/formatter.rs
+++ b/src/renamer/formatter.rs
@@ -26,7 +26,7 @@ impl Renamer {
             .iter()
             .map(|workspace| {
                 let mut counted =
-                    generate_counted_clients(workspace.clients.clone(), config.format.dedup_active);
+                    generate_counted_clients(workspace.clients.clone(), config.format.dedup);
 
                 let workspace_output = counted
                     .iter_mut()
@@ -45,8 +45,8 @@ impl Renamer {
         let config_format = &config.format;
         let client = client.clone();
 
-        let is_dedup_active = config_format.dedup_active && (counter > 1);
-        let is_dedup_inactive = config_format.dedup_inactive;
+        let is_dedup_active = config_format.dedup && (counter > 1);
+        let is_dedup_inactive = config_format.dedup_inactive_fullscreen;
 
         let counter_sup = to_superscript(counter);
         let prev_counter = (counter - 1).to_string();

--- a/src/renamer/formatter.rs
+++ b/src/renamer/formatter.rs
@@ -45,8 +45,8 @@ impl Renamer {
         let config_format = &config.format;
         let client = client.clone();
 
-        let is_dedup_active = config_format.dedup && (counter > 1);
-        let is_dedup_inactive = config_format.dedup_inactive_fullscreen;
+        let is_dedup = config_format.dedup && (counter > 1);
+        let is_dedup_inactive_fullscreen = config_format.dedup_inactive_fullscreen;
 
         let counter_sup = to_superscript(counter);
         let prev_counter = (counter - 1).to_string();
@@ -92,9 +92,10 @@ impl Renamer {
             println!("client: {:?}\nformatter vars => {:#?}", client, vars);
         }
 
-        let is_grouped = client.is_fullscreen && (client.is_active || !is_dedup_inactive);
+        let is_grouped =
+            client.is_fullscreen && (client.is_active || !is_dedup_inactive_fullscreen);
 
-        match (is_grouped, is_dedup_active) {
+        match (is_grouped, is_dedup) {
             (true, true) => formatter(fmt_client_dup_fullscreen, &vars),
             (false, true) => formatter(fmt_client_dup, &vars),
             (true, false) => formatter(fmt_client_fullscreen, &vars),

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -32,6 +32,7 @@ pub struct AppClient {
     title: String,
     is_active: bool,
     is_fullscreen: bool,
+    is_dedup_inactive: bool,
     matched_rule: IconConfig,
 }
 
@@ -39,17 +40,18 @@ impl PartialEq for AppClient {
     fn eq(&self, other: &Self) -> bool {
         self.matched_rule == other.matched_rule
             && self.is_active == other.is_active
-            && self.is_fullscreen == other.is_fullscreen
+            && (self.is_dedup_inactive || self.is_fullscreen == other.is_fullscreen)
     }
 }
 
 impl AppClient {
-    fn new(client: Client, is_active: bool, matched_rule: IconConfig) -> Self {
+    fn new(client: Client, is_active: bool, more_dedup: bool, matched_rule: IconConfig) -> Self {
         AppClient {
             class: client.class,
             title: client.title,
             is_active,
             is_fullscreen: client.fullscreen,
+            is_dedup_inactive: more_dedup,
             matched_rule,
         }
     }
@@ -114,6 +116,7 @@ impl Renamer {
                 .push(AppClient::new(
                     client.clone(),
                     is_active,
+                    config.format.dedup_inactive,
                     self.parse_icon(client.class, client.title, is_active, config),
                 ));
         }
@@ -275,6 +278,7 @@ mod tests {
             is_active: false,
             is_fullscreen: false,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
+            is_dedup_inactive: false,
         };
 
         let client2 = AppClient {
@@ -283,6 +287,7 @@ mod tests {
             is_active: false,
             is_fullscreen: false,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
+            is_dedup_inactive: false,
         };
 
         let client3 = AppClient {
@@ -291,6 +296,7 @@ mod tests {
             is_active: true,
             is_fullscreen: false,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
+            is_dedup_inactive: false,
         };
 
         let client4 = AppClient {
@@ -299,6 +305,7 @@ mod tests {
             is_active: false,
             is_fullscreen: true,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
+            is_dedup_inactive: false,
         };
 
         let client5 = AppClient {
@@ -307,6 +314,7 @@ mod tests {
             is_active: false,
             is_fullscreen: true,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
+            is_dedup_inactive: false,
         };
 
         let client6 = AppClient {
@@ -315,6 +323,7 @@ mod tests {
             is_active: false,
             is_fullscreen: false,
             matched_rule: IconConfig::Class("alacritty".to_string(), "term".to_string()),
+            is_dedup_inactive: false,
         };
 
         assert_eq!(client1 == client2, true);
@@ -331,7 +340,7 @@ mod tests {
             .icons
             .push((Regex::new("(kitty|alacritty)").unwrap(), "term".to_string()));
 
-        config.format.dedup = true;
+        config.format.dedup_active = true;
         config.format.client_dup = "{icon}{counter}".to_string();
 
         let renamer = Renamer::new(
@@ -364,6 +373,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -376,6 +386,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -388,6 +399,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -400,6 +412,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -412,6 +425,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -432,7 +446,7 @@ mod tests {
             .icons
             .push((Regex::new("alacritty").unwrap(), "term".to_string()));
 
-        config.format.dedup = true;
+        config.format.dedup_active = true;
         config.format.client_dup = "{icon}{counter}".to_string();
 
         let renamer = Renamer::new(
@@ -465,6 +479,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -477,6 +492,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -489,6 +505,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -501,6 +518,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -513,6 +531,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -569,6 +588,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -581,6 +601,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -593,6 +614,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -605,6 +627,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -617,6 +640,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -666,6 +690,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -678,6 +703,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -690,6 +716,7 @@ mod tests {
                             true,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -702,6 +729,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -714,6 +742,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -764,6 +793,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -776,6 +806,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -788,6 +819,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -800,6 +832,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -812,6 +845,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -862,6 +896,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -874,6 +909,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -886,6 +922,7 @@ mod tests {
                             true,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -898,6 +935,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -910,6 +948,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -925,7 +964,7 @@ mod tests {
         config
             .icons
             .push((Regex::new("kitty").unwrap(), "term".to_string()));
-        config.format.dedup = true;
+        config.format.dedup_active = true;
         config.format.client_dup = "{icon}{counter}".to_string();
 
         let renamer = Renamer::new(
@@ -953,6 +992,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -960,6 +1000,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -967,6 +1008,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -974,6 +1016,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -981,6 +1024,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -997,7 +1041,7 @@ mod tests {
             .icons
             .push((Regex::new("kitty").unwrap(), "term".to_string()));
 
-        config.format.dedup = true;
+        config.format.dedup_active = true;
         config.format.client_dup = "{icon}{counter}".to_string();
         config.format.client_active = "*{icon}*".to_string();
         config.format.client_dup_active = "{icon}{counter_unfocused}".to_string();
@@ -1032,6 +1076,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1044,6 +1089,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1056,6 +1102,7 @@ mod tests {
                             true,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1068,6 +1115,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1080,6 +1128,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -1096,7 +1145,7 @@ mod tests {
             .icons
             .push((Regex::new("kitty").unwrap(), "term".to_string()));
 
-        config.format.dedup = true;
+        config.format.dedup_active = true;
         config.format.client_dup = "{icon}{counter}".to_string();
         config.format.client_dup_fullscreen =
             "[{icon}]{delim}{icon}{counter_unfocused_sup}".to_string();
@@ -1131,6 +1180,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1143,6 +1193,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1155,6 +1206,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1167,6 +1219,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1179,6 +1232,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -1194,7 +1248,7 @@ mod tests {
         config
             .icons
             .push((Regex::new("kitty").unwrap(), "term".to_string()));
-        config.format.dedup = true;
+        config.format.dedup_active = true;
         config.format.client = "{icon}".to_string();
         config.format.client_active = "*{icon}*".to_string();
         config.format.client_fullscreen = "[{icon}]".to_string();
@@ -1233,6 +1287,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1245,6 +1300,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1257,6 +1313,7 @@ mod tests {
                             true,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1269,6 +1326,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1281,6 +1339,7 @@ mod tests {
                             false,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -1342,6 +1401,7 @@ mod tests {
                             true,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -1354,6 +1414,7 @@ mod tests {
                             true,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                     AppClient {
                         class: "qute".to_string(),
@@ -1366,6 +1427,7 @@ mod tests {
                             true,
                             &config,
                         ),
+                        is_dedup_inactive: false,
                     },
                 ],
             }],
@@ -1413,6 +1475,7 @@ mod tests {
                         true,
                         &config,
                     ),
+                    is_dedup_inactive: false,
                 }],
             }],
             &config,
@@ -1449,6 +1512,7 @@ mod tests {
                         true,
                         &config,
                     ),
+                    is_dedup_inactive: false,
                 }],
             }],
             &config,

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -32,7 +32,7 @@ pub struct AppClient {
     title: String,
     is_active: bool,
     is_fullscreen: bool,
-    is_dedup_inactive: bool,
+    is_dedup_inactive_fullscreen: bool,
     matched_rule: IconConfig,
 }
 
@@ -40,7 +40,7 @@ impl PartialEq for AppClient {
     fn eq(&self, other: &Self) -> bool {
         self.matched_rule == other.matched_rule
             && self.is_active == other.is_active
-            && (self.is_dedup_inactive || self.is_fullscreen == other.is_fullscreen)
+            && (self.is_dedup_inactive_fullscreen || self.is_fullscreen == other.is_fullscreen)
     }
 }
 
@@ -51,7 +51,7 @@ impl AppClient {
             title: client.title,
             is_active,
             is_fullscreen: client.fullscreen,
-            is_dedup_inactive: more_dedup,
+            is_dedup_inactive_fullscreen: more_dedup,
             matched_rule,
         }
     }
@@ -116,7 +116,7 @@ impl Renamer {
                 .push(AppClient::new(
                     client.clone(),
                     is_active,
-                    config.format.dedup_inactive,
+                    config.format.dedup_inactive_fullscreen,
                     self.parse_icon(client.class, client.title, is_active, config),
                 ));
         }
@@ -278,7 +278,7 @@ mod tests {
             is_active: false,
             is_fullscreen: false,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
-            is_dedup_inactive: false,
+            is_dedup_inactive_fullscreen: false,
         };
 
         let client2 = AppClient {
@@ -287,7 +287,7 @@ mod tests {
             is_active: false,
             is_fullscreen: false,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
-            is_dedup_inactive: false,
+            is_dedup_inactive_fullscreen: false,
         };
 
         let client3 = AppClient {
@@ -296,7 +296,7 @@ mod tests {
             is_active: true,
             is_fullscreen: false,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
-            is_dedup_inactive: false,
+            is_dedup_inactive_fullscreen: false,
         };
 
         let client4 = AppClient {
@@ -305,7 +305,7 @@ mod tests {
             is_active: false,
             is_fullscreen: true,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
-            is_dedup_inactive: false,
+            is_dedup_inactive_fullscreen: false,
         };
 
         let client5 = AppClient {
@@ -314,7 +314,7 @@ mod tests {
             is_active: false,
             is_fullscreen: true,
             matched_rule: IconConfig::Class("(kitty|alacritty)".to_string(), "term".to_string()),
-            is_dedup_inactive: false,
+            is_dedup_inactive_fullscreen: false,
         };
 
         let client6 = AppClient {
@@ -323,7 +323,7 @@ mod tests {
             is_active: false,
             is_fullscreen: false,
             matched_rule: IconConfig::Class("alacritty".to_string(), "term".to_string()),
-            is_dedup_inactive: false,
+            is_dedup_inactive_fullscreen: false,
         };
 
         assert_eq!(client1 == client2, true);
@@ -340,7 +340,7 @@ mod tests {
             .icons
             .push((Regex::new("(kitty|alacritty)").unwrap(), "term".to_string()));
 
-        config.format.dedup_active = true;
+        config.format.dedup = true;
         config.format.client_dup = "{icon}{counter}".to_string();
 
         let renamer = Renamer::new(
@@ -373,7 +373,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -386,7 +386,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -399,7 +399,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -412,7 +412,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -425,7 +425,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -446,7 +446,7 @@ mod tests {
             .icons
             .push((Regex::new("alacritty").unwrap(), "term".to_string()));
 
-        config.format.dedup_active = true;
+        config.format.dedup = true;
         config.format.client_dup = "{icon}{counter}".to_string();
 
         let renamer = Renamer::new(
@@ -479,7 +479,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -492,7 +492,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -505,7 +505,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -518,7 +518,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -531,7 +531,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -588,7 +588,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -601,7 +601,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -614,7 +614,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -627,7 +627,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -640,7 +640,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -690,7 +690,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -703,7 +703,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -716,7 +716,7 @@ mod tests {
                             true,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -729,7 +729,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -742,7 +742,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -793,7 +793,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -806,7 +806,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -819,7 +819,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -832,7 +832,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -845,7 +845,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -896,7 +896,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -909,7 +909,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -922,7 +922,7 @@ mod tests {
                             true,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -935,7 +935,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -948,7 +948,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -964,7 +964,7 @@ mod tests {
         config
             .icons
             .push((Regex::new("kitty").unwrap(), "term".to_string()));
-        config.format.dedup_active = true;
+        config.format.dedup = true;
         config.format.client_dup = "{icon}{counter}".to_string();
 
         let renamer = Renamer::new(
@@ -992,7 +992,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1000,7 +1000,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1008,7 +1008,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1016,7 +1016,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1024,7 +1024,7 @@ mod tests {
                         is_active: false,
                         is_fullscreen: false,
                         matched_rule: IconConfig::Class("kitty".to_string(), "term".to_string()),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -1041,7 +1041,7 @@ mod tests {
             .icons
             .push((Regex::new("kitty").unwrap(), "term".to_string()));
 
-        config.format.dedup_active = true;
+        config.format.dedup = true;
         config.format.client_dup = "{icon}{counter}".to_string();
         config.format.client_active = "*{icon}*".to_string();
         config.format.client_dup_active = "{icon}{counter_unfocused}".to_string();
@@ -1076,7 +1076,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1089,7 +1089,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1102,7 +1102,7 @@ mod tests {
                             true,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1115,7 +1115,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1128,7 +1128,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -1145,7 +1145,7 @@ mod tests {
             .icons
             .push((Regex::new("kitty").unwrap(), "term".to_string()));
 
-        config.format.dedup_active = true;
+        config.format.dedup = true;
         config.format.client_dup = "{icon}{counter}".to_string();
         config.format.client_dup_fullscreen =
             "[{icon}]{delim}{icon}{counter_unfocused_sup}".to_string();
@@ -1180,7 +1180,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1193,7 +1193,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1206,7 +1206,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1219,7 +1219,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1232,7 +1232,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -1248,7 +1248,7 @@ mod tests {
         config
             .icons
             .push((Regex::new("kitty").unwrap(), "term".to_string()));
-        config.format.dedup_active = true;
+        config.format.dedup = true;
         config.format.client = "{icon}".to_string();
         config.format.client_active = "*{icon}*".to_string();
         config.format.client_fullscreen = "[{icon}]".to_string();
@@ -1287,7 +1287,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1300,7 +1300,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1313,7 +1313,7 @@ mod tests {
                             true,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1326,7 +1326,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "kitty".to_string(),
@@ -1339,7 +1339,7 @@ mod tests {
                             false,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -1401,7 +1401,7 @@ mod tests {
                             true,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "alacritty".to_string(),
@@ -1414,7 +1414,7 @@ mod tests {
                             true,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                     AppClient {
                         class: "qute".to_string(),
@@ -1427,7 +1427,7 @@ mod tests {
                             true,
                             &config,
                         ),
-                        is_dedup_inactive: false,
+                        is_dedup_inactive_fullscreen: false,
                     },
                 ],
             }],
@@ -1475,7 +1475,7 @@ mod tests {
                         true,
                         &config,
                     ),
-                    is_dedup_inactive: false,
+                    is_dedup_inactive_fullscreen: false,
                 }],
             }],
             &config,
@@ -1512,13 +1512,204 @@ mod tests {
                         true,
                         &config,
                     ),
-                    is_dedup_inactive: false,
+                    is_dedup_inactive_fullscreen: false,
                 }],
             }],
             &config,
         );
 
         let expected = [(1, "\u{f059} kitty".to_string())].into_iter().collect();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_dedup_inactive_fullscreen() {
+        let mut config = crate::config::read_config_file(None).unwrap();
+
+        config
+            .icons
+            .push((Regex::new("kitty").unwrap(), "term".to_string()));
+
+        config.format.client_dup = "{icon}{counter}".to_string();
+        config.format.dedup = true;
+        config.format.dedup_inactive_fullscreen = true;
+        config.format.client = "{icon}".to_string();
+        config.format.client_active = "*{icon}*".to_string();
+        config.format.client_fullscreen = "[{icon}]".to_string();
+        config.format.client_dup_fullscreen =
+            "[{icon}]{delim}{icon}{counter_unfocused}".to_string();
+        config.format.client_dup_active = "*{icon}*{delim}{icon}{counter_unfocused}".to_string();
+
+        let mut renamer = Renamer::new(
+            Config {
+                cfg_path: None,
+                config: config.clone(),
+            },
+            Args {
+                verbose: false,
+                debug: false,
+                config: None,
+                dump: false,
+            },
+        );
+
+        let expected = [(1, "*term*".to_string()), (2, "term3".to_string())]
+            .into_iter()
+            .collect();
+
+        let actual = renamer.generate_workspaces_string(
+            vec![
+                AppWorkspace {
+                    id: 1,
+                    clients: vec![AppClient {
+                        class: "kitty".to_string(),
+                        title: "~".to_string(),
+                        is_active: true,
+                        is_fullscreen: false,
+                        matched_rule: renamer.parse_icon(
+                            "kitty".to_string(),
+                            "~".to_string(),
+                            true,
+                            &config,
+                        ),
+                        is_dedup_inactive_fullscreen: false,
+                    }],
+                },
+                AppWorkspace {
+                    id: 2,
+                    clients: vec![
+                        AppClient {
+                            class: "kitty".to_string(),
+                            title: "~".to_string(),
+                            is_active: false,
+                            is_fullscreen: true,
+                            matched_rule: renamer.parse_icon(
+                                "kitty".to_string(),
+                                "~".to_string(),
+                                false,
+                                &config,
+                            ),
+                            is_dedup_inactive_fullscreen: false,
+                        },
+                        AppClient {
+                            class: "kitty".to_string(),
+                            title: "~".to_string(),
+                            is_active: false,
+                            is_fullscreen: true,
+                            matched_rule: renamer.parse_icon(
+                                "kitty".to_string(),
+                                "~".to_string(),
+                                false,
+                                &config,
+                            ),
+                            is_dedup_inactive_fullscreen: false,
+                        },
+                        AppClient {
+                            class: "kitty".to_string(),
+                            title: "~".to_string(),
+                            is_active: false,
+                            is_fullscreen: true,
+                            matched_rule: renamer.parse_icon(
+                                "kitty".to_string(),
+                                "~".to_string(),
+                                true,
+                                &config,
+                            ),
+                            is_dedup_inactive_fullscreen: false,
+                        },
+                    ],
+                },
+            ],
+            &config,
+        );
+
+        assert_eq!(actual, expected);
+
+        config.format.dedup_inactive_fullscreen = false;
+
+        renamer = Renamer::new(
+            Config {
+                cfg_path: None,
+                config: config.clone(),
+            },
+            Args {
+                verbose: false,
+                debug: false,
+                config: None,
+                dump: false,
+            },
+        );
+
+        let expected = [(1, "*term*".to_string()), (2, "[term] term2".to_string())]
+            .into_iter()
+            .collect();
+
+        let actual = renamer.generate_workspaces_string(
+            vec![
+                AppWorkspace {
+                    id: 1,
+                    clients: vec![AppClient {
+                        class: "kitty".to_string(),
+                        title: "~".to_string(),
+                        is_active: true,
+                        is_fullscreen: false,
+                        matched_rule: renamer.parse_icon(
+                            "kitty".to_string(),
+                            "~".to_string(),
+                            true,
+                            &config,
+                        ),
+                        is_dedup_inactive_fullscreen: false,
+                    }],
+                },
+                AppWorkspace {
+                    id: 2,
+                    clients: vec![
+                        AppClient {
+                            class: "kitty".to_string(),
+                            title: "~".to_string(),
+                            is_active: false,
+                            is_fullscreen: true,
+                            matched_rule: renamer.parse_icon(
+                                "kitty".to_string(),
+                                "~".to_string(),
+                                false,
+                                &config,
+                            ),
+                            is_dedup_inactive_fullscreen: false,
+                        },
+                        AppClient {
+                            class: "kitty".to_string(),
+                            title: "~".to_string(),
+                            is_active: false,
+                            is_fullscreen: true,
+                            matched_rule: renamer.parse_icon(
+                                "kitty".to_string(),
+                                "~".to_string(),
+                                false,
+                                &config,
+                            ),
+                            is_dedup_inactive_fullscreen: false,
+                        },
+                        AppClient {
+                            class: "kitty".to_string(),
+                            title: "~".to_string(),
+                            is_active: false,
+                            is_fullscreen: true,
+                            matched_rule: renamer.parse_icon(
+                                "kitty".to_string(),
+                                "~".to_string(),
+                                true,
+                                &config,
+                            ),
+                            is_dedup_inactive_fullscreen: false,
+                        },
+                    ],
+                },
+            ],
+            &config,
+        );
 
         assert_eq!(actual, expected);
     }

--- a/src/renamer/mod.rs
+++ b/src/renamer/mod.rs
@@ -45,13 +45,18 @@ impl PartialEq for AppClient {
 }
 
 impl AppClient {
-    fn new(client: Client, is_active: bool, more_dedup: bool, matched_rule: IconConfig) -> Self {
+    fn new(
+        client: Client,
+        is_active: bool,
+        is_dedup_inactive_fullscreen: bool,
+        matched_rule: IconConfig,
+    ) -> Self {
         AppClient {
             class: client.class,
             title: client.title,
             is_active,
             is_fullscreen: client.fullscreen,
-            is_dedup_inactive_fullscreen: more_dedup,
+            is_dedup_inactive_fullscreen,
             matched_rule,
         }
     }


### PR DESCRIPTION
This will deduplicate more when the workspace is inactive, remove fullscreen and active window indicator

- Add more deduplication options to the renamer function
- Update configuration to include new options and better explain existing options in comments.
