### PR TITLE
fix: default class formatting

### DIFF
--- a/src/renamer/icon.rs
+++ b/src/renamer/icon.rs
@@ -28,11 +28,6 @@ impl IconConfig {
         icon
     }
 
-    pub fn rule(&self) -> Rule {
-        let (rule, _, _) = self.get();
-        rule
-    }
-
     pub fn captures(&self) -> Captures {
         let (_, _, captures) = self.get();
         captures
@@ -64,12 +59,6 @@ impl IconStatus {
     pub fn icon(&self) -> Icon {
         match self {
             Active(config) | Inactive(config) => config.icon(),
-        }
-    }
-
-    pub fn rule(&self) -> Rule {
-        match self {
-            Active(config) | Inactive(config) => config.rule(),
         }
     }
 
@@ -213,9 +202,7 @@ impl Renamer {
         let icon_default_active = self
             .find_icon("DEFAULT", "DEFAULT", "", "", true, config)
             .unwrap_or({
-                self.find_icon("DEFAULT", "DEFAULT", "", "", false, config)
-                    .map(|i| Active(Class(i.rule(), i.icon())))
-                    .unwrap_or(Active(Default("no icon".to_string())))
+                icon_default.clone()
             });
 
         if is_active {


### PR DESCRIPTION
## Description

Default class strings did not respect active formatting configurations. This is because the pattern matcher that applies formatting only does so if the client is simultaneously [active and with an inactive matched rule](https://github.com/hyprland-community/hyprland-autoname-workspaces/blob/ba126d55bccfbfbf7dd461b72e617796192693cc/src/renamer/formatter.rs#L85).

There was a bug with inactive default rules that caused them to [always be marked as active when the client was active](https://github.com/hyprland-community/hyprland-autoname-workspaces/blob/ba126d55bccfbfbf7dd461b72e617796192693cc/src/renamer/icon.rs#L216-L218).

This PR ensures that inactive default rules are evaluated as inactive even when the client is currently active - allowing formatting to be applied.

Fixes #108 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

New unit test added. Tested default class formatting behavior on my local system.