### PR TITLE
Bump version to 1.1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "hyprland-autoname-workspaces"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "clap",
  "hyprland",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyprland-autoname-workspaces"
 authors = ["Cyril Levis", "Maxim Baz"]
-version = "1.1.15"
+version = "1.1.16"
 edition = "2021"
 categories = ["gui"]
 keywords = ["linux", "desktop-application", "hyprland", "waybar", "wayland"]

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,4 +1,4 @@
-version = "1.1.15"
+version = "1.1.16"
 
 [format]
 dedup = true


### PR DESCRIPTION
## Description

This simply bumps the version to 1.1.16 so we can tag and do a fresh release containing these changes: https://github.com/hyprland-community/hyprland-autoname-workspaces/compare/1.1.15...c407bdf3f01b40eb003aa1fbd39b32b2c16adc4f